### PR TITLE
Cli

### DIFF
--- a/blockchain.py
+++ b/blockchain.py
@@ -4,6 +4,7 @@ import hashlib
 from collections import namedtuple
 from time import time
 from pathlib import Path
+from utils import print_debug_info
 
 Transaction = namedtuple(
     'Transaction', ['sender', 'recipient', 'amount', 'fee', 'timestamp', 'signature'])
@@ -47,7 +48,7 @@ class Blockchain (object):
     def load_chain(self):
         # TODO: Load preexisting blockchain from file
          if os.path.exists("bc_file.txt") and os.stat("bc_file.txt").st_size != 0 and Path('bc_file.txt').is_file():
-             print("### DEBUG ### load existing blockchain from file")
+             print_debug_info("### DEBUG ### load existing blockchain from file")
              with open('bc_file.txt', 'rb') as input:
                  self.chain = pickle.load(input)
          else:
@@ -63,7 +64,7 @@ class Blockchain (object):
         # Make sure, only one mining reward is granted per block
         for pool_transaction in self.transaction_pool:
             if pool_transaction.sender == '0' and pool_transaction.signature == '0':
-                print('### DEBUG ### This block already granted a mining transaction!')
+                print_debug_info('### DEBUG ### This block already granted a mining transaction!')
                 return
         if transaction in self.latest_block().transactions:
             return
@@ -71,7 +72,7 @@ class Blockchain (object):
             self.transaction_pool.append(transaction)
             self.send_queue.put(('new_transaction', transaction, 'broadcast'))
         else:
-            print('### DEBUG ### Invalid transaction')
+            print_debug_info('### DEBUG ### Invalid transaction')
 
     def new_block(self, block):
         """ Add a new block to the blockchain
@@ -90,7 +91,7 @@ class Blockchain (object):
             self.chain.append(block)
             self.send_queue.put(('new_block', block, 'broadcast'))
         else:
-            print('### DEBUG ### Invalid block')
+            print_debug_info('### DEBUG ### Invalid block')
 
     def validate_block(self, block, last_block):
         """ Validate a block

--- a/core.py
+++ b/core.py
@@ -16,6 +16,7 @@ from GUI import *
 import blockchain
 import networking
 from pow_chain import Block, PoW_Blockchain, Transaction
+from utils import print_debug_info, set_debug
 
 # Create queues for message transfer blockchain<->networking
 # Every message on the send_queue should be sent to all connected
@@ -76,7 +77,7 @@ def receive_msg(msg_type, msg_data, msg_address, blockchain):
 def blockchain_loop(blockchain):
     while True:
         msg_type, msg_data, msg_address = receive_queue.get()
-        print('### DEBUG ### Processing: ' + msg_type)
+        print_debug_info('### DEBUG ### Processing: ' + msg_type)
         receive_msg(msg_type, msg_data, msg_address, blockchain)
 
 
@@ -109,14 +110,14 @@ def resolve_name(name):
     try:
         return keystore[name]
     except KeyError:
-        print('### DEBUG ### Unknown name')
+        print_debug_info('### DEBUG ### Unknown name')
         return 'Error'
 
 
 def add_to_keystore(name, key):
     try:
         if keystore[name]:
-            print('### DEBUG ### Name already exists, use update if you want to change the respective key')
+            print('Name already exists, use update if you want to change the respective key')
             return
     except KeyError:
         keystore[name] = key
@@ -135,13 +136,16 @@ def main(argv=sys.argv):
     port = 6666
     signing_key = None
     try:
-        opts, args = getopt.getopt(argv[1:], 'hp=k=s=', ['help', 'port=', 'key=', 'store='])
+        opts, args = getopt.getopt(argv[1:], 'hdp=k=s=', ['help',  'debug', 'port=', 'key=', 'store='])
         for o, a in opts:
             if o in ('-h', '--help'):
+                print('-d/--debug to enable debug prints')
                 print('-p/--port to change default port')
                 print('-k/--key to load a private key from a file')
                 print('-s/--store to load a keystore from a file')
                 sys.exit()
+            if o in ('-d', '--debug'):
+                set_debug()
             if o in ('-p', '--port'):
                 try:
                     port = int(a)

--- a/networking.py
+++ b/networking.py
@@ -5,6 +5,7 @@ import time
 import sys
 from queue import Empty
 from pprint import pprint
+from utils import print_debug_info
 
 from blockchain import Block, Transaction
 
@@ -86,7 +87,7 @@ def process_incoming_msg(msg, in_address, receive_queue):
     receive_queue -> Queue for communication with the blockchain
     """
     msg_type, msg_data = unpack_msg(msg)
-    print('### DEBUG ### received: ' + msg_type)
+    print_debug_info('### DEBUG ### received: ' + msg_type)
     if msg_type.startswith('N_'):
         # networking messages
         if msg_type == 'N_new_peer':
@@ -251,7 +252,7 @@ def worker(send_queue, receive_queue, command_queue, port=6666):
     send_queue -> Queue for messages to other nodes
     receive_queue -> Queue for messages to the attached blockchain
     """
-    print("### DEBUG ### Started networking")
+    print_debug_info("### DEBUG ### Started networking")
     # Example:
     # Find peers
     # Main loop:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,11 @@
+debug = False
+
+
+def print_debug_info(msg):
+    if debug:
+        print(msg)
+
+
+def set_debug():
+    global debug
+    debug = True


### PR DESCRIPTION
Added balance command to display the current balance of either the user or any given account resolved by the name via the keystore.
Commands are normalized to be always recognized. As long as it's a correct command the command will be accepted as valid input.
Added a queue to issue commands to the networker thread.
Made the print peers command threadsafe by issuing a command to the networker thread via the command queue.
Added utils.py for general utility functions.
Added print_debug_info() to print debug logs, when starting the client with the -d/--debug flag.
Replaced all normal debug prints with print_debug_info()